### PR TITLE
Removing the master and slave words

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Pigeon Computer'

--- a/pigeon/xerblin/TextViewer.py
+++ b/pigeon/xerblin/TextViewer.py
@@ -311,7 +311,7 @@ class TextViewerWidget(Text, mousebindingsmixin):
         foreground = "orange"
     )
 
-    def __init__(self, master=None,  **kw):
+    def __init__(self, main=None,  **kw):
 
         # Get the filename associated with this widget's contents, if any.
         self.filename = kw.pop('filename', False)
@@ -324,7 +324,7 @@ class TextViewerWidget(Text, mousebindingsmixin):
         kw.setdefault('font', 'arial 12')
 
         #Create ourselves as a Tkinter Text
-        Text.__init__(self, master, **kw)
+        Text.__init__(self, main, **kw)
 
         #Initialize our mouse mixin.
         mousebindingsmixin.__init__(self)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.